### PR TITLE
Add 'Artistic Style' options to the Makefile

### DIFF
--- a/source/tests/canpie-fd/Makefile
+++ b/source/tests/canpie-fd/Makefile
@@ -28,7 +28,7 @@ DEBUG      = 0
 #---------------------------------------------------------------
 # PRJ_DIR: absolute or relative path to project root directory
 #
-PRJ_DIR	= .
+PRJ_DIR		= .
 
 #---------------------------------------------------------------
 # DEV_DIR: path to device directory
@@ -38,17 +38,17 @@ DEV_DIR 	= $(PRJ_DIR)/../../device/template
 #---------------------------------------------------------------
 # CAN_DIR: path to canpie-fd directory
 #
-CAN_DIR  = $(PRJ_DIR)/../../canpie-fd
+CAN_DIR  	= $(PRJ_DIR)/../../canpie-fd
 
 #---------------------------------------------------------------
 # TEST_DIR: path to test directory
 #
-TEST_DIR	= $(PRJ_DIR)
+TEST_DIR 	= $(PRJ_DIR)
 
 #----------------------------------------------------------
 # Object directory
 #
-OBJ_DIR	= $(PRJ_DIR)
+OBJ_DIR		= $(PRJ_DIR)
 
 
 #-----------------------------------------------------------------------------#
@@ -56,8 +56,9 @@ OBJ_DIR	= $(PRJ_DIR)
 #                                                                             #
 #-----------------------------------------------------------------------------#
 ifeq ($(OS),Windows_NT)
-	CC ="D:/devtools/cygwin/bin/gcc"
-	SPLINT=  "d:/devtools/splint/splint-3.1.2/bin/splint.exe"
+	CC 		= "D:/devtools/cygwin/bin/gcc"
+	SPLINT	= "d:/devtools/splint/splint-3.1.2/bin/splint.exe"
+	ASTYLE	= "D:/devtools/AStyle/bin/AStyle.exe"
 else
 
 endif
@@ -74,7 +75,8 @@ INC_DIR  += -I $(TEST_DIR)
 # Set VPATH to the same value like include paths
 # but without '-I'
 VPATH =$(INC_DIR:-I= )
-ALL_CFILES = $(wildcard $(CAN_DIR)/*.c $(DEV_DIR)/*.c)
+ALL_CFILES = $(wildcard $(TEST_DIR)/*.c)
+ALL_HFILES = $(wildcard $(TEST_DIR)/*.h)
 
 #---------------------------------------------------------------
 # Warning level
@@ -147,13 +149,12 @@ LFLAGS  += $(GDB_FLAG)
 # MISRA-C checker settings																		#
 # The TI checker generates false positives for 10.1, 10.5 and 17.6   			#
 #-----------------------------------------------------------------------------#
-
-MISRA_DIR   = /Applications/TexasInstruments/ccsv7/tools/compiler/ti-cgt-arm_16.9.0.LTS
-MCC   		= $(MISRA_DIR)/bin/armcl
-MFLAGS      = --check_misra="all,-2.2,-5.7,-10.1,-10.5,-17.6" 
-MFLAGS     += --misra_advisory=warning --misra_required=warning
-MFLAGS     += $(INC_DIR)
-MFLAGS 	  += -I $(MISRA_DIR)/include
+MISRA_DIR	 = /Applications/TexasInstruments/ccsv7/tools/compiler/ti-cgt-arm_16.9.0.LTS
+MCC  			 = $(MISRA_DIR)/bin/armcl
+MFLAGS 		 = --check_misra="all,-2.2,-5.7,-10.1,-10.5,-17.6" 
+MFLAGS		+= --misra_advisory=warning --misra_required=warning
+MFLAGS		+= $(INC_DIR)
+MFLAGS 	  	+= -I $(MISRA_DIR)/include
 
 #-----------------------------------------------------------------------------#
 # List of object files that need to be compiled                               #
@@ -174,25 +175,23 @@ CAN_SRC  = cp_msg.c
 #--------------------------------------------------------------------
 DEV_SRC	=	
 
-#device_canfd.c
-
 
 #--------------------------------------------------------------------
 # Unit test source
 # compiled if TEST_OBJS==1
 #--------------------------------------------------------------------
 
-FUNC_SRC =	test_cp_main_f.c			\
-				test_cp_msg_ccf.c			\
-				test_cp_msg_fdf.c			\
-				unity_fixture.c			\
-				unity.c
+FUNC_SRC 	=	test_cp_main_f.c	\
+					test_cp_msg_ccf.c	\
+					test_cp_msg_fdf.c	\
+					unity_fixture.c	\
+					unity.c
 
-MACRO_SRC =	test_cp_main_m.c			\
-				test_cp_msg_ccm.c			\
-				test_cp_msg_fdm.c			\
-				unity_fixture.c			\
-				unity.c
+MACRO_SRC =	test_cp_main_m.c	\
+					test_cp_msg_ccm.c	\
+					test_cp_msg_fdm.c	\
+					unity_fixture.c	\
+					unity.c
 
 
 #--------------------------------------------------------------------
@@ -206,6 +205,23 @@ FUNC_OBJS += $(patsubst %.c,$(OBJ_DIR)/%.o, $(CAN_SRC))
 MACRO_OBJS  = $(patsubst %.c,$(OBJ_DIR)/%.o, $(DEV_SRC))
 MACRO_OBJS += $(patsubst %.c,$(OBJ_DIR)/%.o, $(MACRO_SRC))
 MACRO_OBJS += $(patsubst %.c,$(OBJ_DIR)/%.o, $(CAN_SRC))
+
+
+#--------------------------------------------------------------------
+# Adjust artistic style paramters, so the code style correspond  
+# to MicroControl programming rules. 
+# All options are described by 
+# http://astyle.sourceforge.net/astyle.html
+#--------------------------------------------------------------------
+ASTYLE_OPTIONS  = --style=allman --indent=spaces=3 
+ASTYLE_OPTIONS += --indent-switches --indent-preproc-cond 
+ASTYLE_OPTIONS += --pad-header --pad-comma --unpad-paren 
+ASTYLE_OPTIONS += --lineend=linux --align-pointer=name  
+ASTYLE_OPTIONS += --align-reference=name --max-code-length=80 
+ASTYLE_OPTIONS += --break-after-logical --convert-tabs
+ASTYLE_OPTIONS += --suffix=none --formatted 
+ASTYLE_OPTIONS += --ignore-exclude-errors-x
+
 
 #-----------------------------------------------------------------------------#
 # Rules                                                                       #
@@ -246,6 +262,9 @@ run:
 docs:
 	cd $(DOC_DIR)
 	doxygen
+
+style: 
+	$(ASTYLE) $(ASTYLE_OPTIONS) $(ALL_CFILES) $(ALL_HFILES)
 	
 clean:
 	@rm -f $(OBJ_DIR)/*.o


### PR DESCRIPTION
- Artistic style options have been adjusted to the MicroControl
Programming Rules and have to be tested/checked
- Additionally the style of Makefile have been modified a little bit

_Only when the style fits, this should be applied to the source files!_