### PR TITLE
Update server behaviour

### DIFF
--- a/source/qcan/applications/server/qcan_server_dialog.cpp
+++ b/source/qcan/applications/server/qcan_server_dialog.cpp
@@ -643,12 +643,12 @@ void QCanServerDialog::onNetworkShowState(CAN_State_e teStateV)
          break;
 
       case eCAN_STATE_BUS_WARN:
-         ui.pclTxtStatusBusM->setStyleSheet("QLabel { color : yellow; }");
+         ui.pclTxtStatusBusM->setStyleSheet("QLabel { color : orange; }");
          ui.pclTxtStatusBusM->setText(tr("Warning"));
          break;
 
       case eCAN_STATE_BUS_PASSIVE:
-         ui.pclTxtStatusBusM->setStyleSheet("QLabel { color : yellow; }");
+         ui.pclTxtStatusBusM->setStyleSheet("QLabel { color : orange; }");
          ui.pclTxtStatusBusM->setText(tr("Error passive"));
          break;
 

--- a/source/qcan/qcan_network.cpp
+++ b/source/qcan/qcan_network.cpp
@@ -712,6 +712,11 @@ void QCanNetwork::reset(void)
    ulFramePerSecMaxP = 0;
    ulFrameCntSaveP   = 0;
    teCanStateP   = eCAN_STATE_STOPPED;
+
+   if(pclInterfaceP.isNull() == false)
+   {
+      pclInterfaceP->reset();
+   }
 }
 
 


### PR DESCRIPTION
Add possibility to reset CAN HW device from CANpie server and change colour of CAN status text for warnings from yellow to orange.
