### PR TITLE
add possability to use a external compiler definition

### DIFF
--- a/source/canpie-fd/mc_compiler.h
+++ b/source/canpie-fd/mc_compiler.h
@@ -975,6 +975,15 @@ typedef  long long            int64_t;
 //--------------------------------------------------------------------
 
 
+//--------------------------------------------------------------------
+// Compiler external
+//
+#ifdef CP_COMPILER_EXT
+// This is used if someone must define everything inside the application
+#include "cp_compiler_ext.h"
+#endif
+// End of definition:  CP_COMPILER_EXT
+//--------------------------------------------------------------------
 
 //--------------------------------------------------------------------
 // Test is used compiler has been recognised by checking the


### PR DESCRIPTION
Please can you add this to mc_compiler. With this changes it is possible to use some external compiler definition. I have used CP_ as prefix because it is so strange to use mc_  when the project name is canpie.
But if this the key not to merge I can also change it to MC_ ...

many thanks 